### PR TITLE
Fix number of transferred channels being less than the actual number (endpoint duplicates)

### DIFF
--- a/main.js
+++ b/main.js
@@ -90,6 +90,7 @@ const getSubscriptions = async (type, pageToken = null) => {
       mine: true,
       maxResults: 50,
       pageToken: pageToken ? pageToken : undefined,
+      order: 'alphabetical',
     });
     response.result.items.forEach((element) => {
       userData[element.snippet.resourceId.channelId] = element.snippet.title;


### PR DESCRIPTION
The default value for order param of the list endpoint is relevence hence the duplicates over pages in any list of subscriptions over the page limit (50)

reference: https://developers.google.com/youtube/v3/docs/subscriptions/list#order
