### PR TITLE
Authenticate using Google Identity Services instead of the deprecated gapi.auth2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@ Please use the below steps as my keys have crossed limits.
 **Steps:**
 
 1. Create a new project on [Google Cloud](http://console.cloud.google.com) and enable YouTube Data API under API & Services.
+   - Link: https://console.cloud.google.com/apis/library/youtube.googleapis.com
 2. Under credentials tab, create a new API key.
+   - Link: https://console.cloud.google.com/apis/credentials
 3. Create an OAUTH consent screen.
-3. Also create an OAUTH client and set 'Authorized JavaScript origins' as `http://localhost:8080`.
-4. Clone the repo and paste the generated API key and Client id on `main.js` (Line 1 and 2).
-5. Run `python -m http.server 8080` from the current directory.
-6. Open `http://localhost:8080` in the browser.
+   - Link: https://console.cloud.google.com/apis/credentials/consent
+4. Also create an OAUTH client and add two entries to 'Authorized JavaScript origins': `http://localhost:8080` and `http://localhost`
+    - Link: https://console.cloud.google.com/apis/credentials/oauthclient
+5. Clone the repo and paste the generated Client id on `main.js` (Line 1).
+6. Run `python -m http.server 8080` from the current directory.
+7. Open `http://localhost:8080` in the browser.

--- a/index.html
+++ b/index.html
@@ -71,7 +71,8 @@
       </p>
     </div>
 
-    <script src="https://apis.google.com/js/api.js"></script>
+    <script async defer src="https://apis.google.com/js/api.js" onload="gapiLoad()"></script>
+    <script async defer src="https://accounts.google.com/gsi/client" onload="gisInit()"></script>
     <script src="./main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Current tree as of today doesn't work for apps created after July 29th, 2022, and will be fully deprecated on March 31, 2023 for older apps: https://developers.google.com/identity/oauth2/web/guides/migration-to-gis

This PR replaces the usage of `gapi.auth2` module in favor of the newly introduced Google Identity Services library.

I used the "new way" (https://developers.google.com/identity/oauth2/web/guides/migration-to-gis#implicit_flow_examples GIS+GAPI callback) of doing things as a reference for the modifications and tested it myself; I wanted to use `yt-migrate` anyway, that's why I made the PR :)

I also added some links to the readme file to speed things up (they're gcp project-agnostic links)

> If I find time next weekend I'll probably create another PR for adding a dry-run functionality, just showing the delta of the two channels' subscriptions without transferring.